### PR TITLE
feat: allow named alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-#!/usr/bin/env node
-function main() {
+#!./node_modules/.bin/babel
+
+function main(alias) {
   const Now = require('now-client');
   const now = Now(); // this looks like it detect the token from ~/.now.json or the env automatically
   const pkg = require(process.cwd() + '/package.json');
@@ -11,17 +12,24 @@ function main() {
       throw new Error('no previous build found to realias to');
     }
 
-    console.log(`getting alias for ${prev.uid} (${prev.url})`);
-    return now.getAliases(prev.uid).then(res => {
-      const first = res.shift(); // expecting a single alias - otherwise ¯\_(ツ)_/¯
-      console.log(`aliasing to ${first.alias}...`);
-      return now.createAlias(latest.uid, first.alias);
-    });
+    if (alias) {
+      console.log(`aliasing to ${alias}...`);
+      return now.createAlias(latest.uid, alias);
+    } else {
+      console.log(`getting alias for ${prev.uid} (${prev.url})`);
+      return now.getAliases(prev.uid).then(res => {
+        const first = res.shift(); // expecting a single alias - otherwise ¯\_(ツ)_/¯
+        console.log(`aliasing to ${first.alias}...`);
+        return now.createAlias(latest.uid, first.alias);
+      });
+    }
+
   });
 }
 
 module.exports = main;
 
 if (!module.parent) {
-  main().then(() => console.log('done')).catch(e => console.error(e));
+  let alias = process.argv.length > 1 && process.argv[process.argv.length - 1];
+  main(alias).then(() => console.log('done')).catch(e => console.error(e));
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,3 +47,17 @@ test('now realias', t => {
     t.deepEqual(spies.createAlias.args[0], [ 2, 'test.com' ]);
   });
 });
+
+test('now realias with given alias', t => {
+  spies.getDeployments = sinon.spy(() => [{
+    uid: 2,
+    name: 'test'
+  }, {
+    uid: 1,
+    name: 'test'
+  }]);
+
+  return main('someAlias').then(() => {
+    t.deepEqual(spies.createAlias.args[0], [ 2, 'someAlias' ]);
+  });
+});


### PR DESCRIPTION
you can now pass an alias to `now-realias`.
this will alias the last deployment to the given alias
can be useful when you have multiple deployments from the same codebase
